### PR TITLE
Updating Astropy deprecated methods relating to "Card" with new method names.

### DIFF
--- a/starlink/Atl.py
+++ b/starlink/Atl.py
@@ -110,8 +110,8 @@ class PyFITSAdapter:
       indicate that there are no more header cards to read.
       """
 
-      if self.index < len( self.hdu.header.ascard ):
-         result = self.hdu.header.ascard[ self.index ].ascardimage()
+      if self.index < len( self.hdu.header.cards ):
+         result = self.hdu.header.cards[ self.index ].image
          self.index += 1
       else:
          result = None

--- a/starlink/ast/test/test_atl.py
+++ b/starlink/ast/test/test_atl.py
@@ -37,6 +37,6 @@ fc.writefits()
 #  Display the headers now in the pyfits primary hdu.
 print()
 print("The non-WCS cards in cobe.fit: ")
-for v in ffile[0].header.ascard:
+for v in ffile[0].header.cards:
    print(v)
 


### PR DESCRIPTION
Deprecated Astropy methods are outputting warning messages:

    WARNING: AstropyDeprecationWarning: The ascard function is deprecated and may be removed in a future version.
            Use the `.cards` attribute instead. [starlink.Atl]
    WARNING: AstropyDeprecationWarning: The CardList class has been deprecated; all its former functionality has been subsumed by the Header class, so CardList objects should not be directly created.  See the PyFITS 3.1.0 CHANGELOG for more details. [astropy.io.fits.card]
    WARNING: AstropyDeprecationWarning: The ascard function is deprecated and may be removed in a future version.
            Use the `.cards` attribute instead. [starlink.Atl]
    WARNING: AstropyDeprecationWarning: The ascardimage function is deprecated and may be removed in a future version.
            Use the `.image` attribute instead. [starlink.Atl]

This pull request should address at least three of them.