### PR TITLE
 Fix exception text if another exception has already occurred

### DIFF
--- a/starlink/ast/Ast.c
+++ b/starlink/ast/Ast.c
@@ -8192,8 +8192,8 @@ static PyObject *FitsChan_getitem( PyObject *self, PyObject *index ){
         PyErr_SetString( PyExc_KeyError, buff );
       }
 
-/* Otherwise, get the keyword to be searched for. */
-   } else {
+/* Otherwise, if the index is a string, get the keyword to be searched for. */
+   } else if( STRING_CHECK( index ) ){
       keyw = GetString( NULL, index );
 
 /* Rewind the FitsChan so that we search all cards. */
@@ -8272,6 +8272,11 @@ static PyObject *FitsChan_getitem( PyObject *self, PyObject *index ){
 
       vals = astFree( vals );
       keyw = astFree( keyw );
+
+/* Report an error for other index data types. */
+   } else {
+      PyErr_SetString( PyExc_TypeError, "Illegal data type for AST "
+                       "FitsChan key." );
    }
 
 /* Re-instate the original current card. */
@@ -8310,8 +8315,8 @@ static int FitsChan_setitem( PyObject *self, PyObject *index, PyObject *value ){
          astDelFits( THIS );
       }
 
-/* Otherwise...get the keyword to be searched for. */
-   } else {
+/* Otherwise, if the index is a string, get the keyword to be searched for. */
+   } else if( STRING_CHECK( index ) ){
       keyw = GetString( NULL, index );
 
 /* If the keyword name is blank, just insert the supplied value (as a
@@ -8384,7 +8389,13 @@ static int FitsChan_setitem( PyObject *self, PyObject *index, PyObject *value ){
       }
 
       keyw = astFree( keyw );
+
+/* Report an error for other index data types. */
+   } else {
+      PyErr_SetString( PyExc_TypeError, "Illegal data type for AST "
+                       "FitsChan key" );
    }
+
    if( !astOK || PyErr_Occurred() ) result = -1;
    TIDY;
    return result;
@@ -9016,6 +9027,11 @@ static int KeyMap_contains( PyObject *self, PyObject *index ) {
       char *key = GetString( NULL, index );
       result = astMapHasKey( THIS, key );
       key = astFree( key );
+
+/* Report an error for other index data types. */
+   } else {
+      PyErr_SetString( PyExc_TypeError, "Illegal data type for AST "
+                       "KeyMap key." );
    }
 
    if( !astOK ) result = -1;
@@ -10070,7 +10086,7 @@ static const char *IntToColour( Plot *self, int colour ){
       if( PyObject_HasAttrString(self->grf, "IntToCol") ){
          PyObject *result = PyObject_CallMethod( self->grf, "IntToCol", "i", colour );
 
-         if( result && result != Py_None) {
+         if( result && result != Py_None && STRING_CHECK( result ) ) {
             char *p = GetString( NULL, result );
             if( p ){
                if( strlen( p ) > MAXLENCOL ) {
@@ -12297,7 +12313,9 @@ static char *GetString( void *mem, PyObject *value ) {
 *        returned string should be stored. This memory will be extended
 *        if required. New memory is allocated if NULL is supplied.
 *     value
-*        The PyObject containing the string to copy.
+*        The PyObject containing the string to copy. This must be a
+*        string object - use the PyObject_Str method before calling this
+*        function to get a string description of other classes of object.
 
 *  Returned Value:
 *     A dynamically allocated copy of the string. It should be freed

--- a/tools/make_exceptions.py
+++ b/tools/make_exceptions.py
@@ -136,7 +136,9 @@ void astPutErr_( int status_value, const char *message ) {
 
 /* Get the existing Exception text */
          PyErr_Fetch( &ptype, &pvalue, &ptraceback );
-         text = GetString( NULL, pvalue );
+         PyObject *str = PyObject_Str( pvalue );
+         text = GetString( NULL, str );
+         Py_DECREF(str);
          if( text ) {
 
 /* Ignore messages that give the C source file and line number since they are
@@ -158,7 +160,9 @@ void astPutErr_( int status_value, const char *message ) {
          }
       }
 
-/* If an AST or non-AST exception has already occurred, return without action. */
+/* If an AST or non-AST exception has already occurred, restore the
+   original AST status value then return without action. */
+      astSetStatus( lstat );
       return;
    }
 


### PR DESCRIPTION
A python exception is raised each time astError() is called within AST. Standard practice is for AST to call astError() several times for each actual error, adding contextual information in each call.  This results in exceptions being raised when another exception has already been raised. The way pyast handles this is to get the text of the existing exception - annulling that exception in the process - and include it in the text of a  new exception, together with the new contextual information. 

But this was not working because the code that got the text from the old exception was wrong., leading to no new exception being raised. This caused the python interpreter to objec, issuing a message that "NULL was returned by function [...] but no exception was raised".

This PR fixes the code that gets the text of the old exception, and also does some extra tidying up that should enable other similar problems to be identified more easily.