### PR TITLE
Add wrapper for astMapMerge

### DIFF
--- a/ast/pyast_extra.c
+++ b/ast/pyast_extra.c
@@ -1,0 +1,119 @@
+/*
+*+
+*  Name:
+*     pyast_extra.c
+
+*  Purpose:
+*     Provide pyast with access to some protected features of AST
+
+*  Type of Module:
+*     C source file.
+
+*  Description:
+*     This file provides public APIs for some protected functions in the
+*     AST library, for use within pyast. The API is defined by the
+*     pyast_extra.h include file.
+
+*  Copyright:
+*     Copyright (C) 2019 East Asian Observatory
+
+*  Licence:
+*     This program is free software: you can redistribute it and/or
+*     modify it under the terms of the GNU Lesser General Public
+*     License as published by the Free Software Foundation, either
+*     version 3 of the License, or (at your option) any later
+*     version.
+*
+*     This program is distributed in the hope that it will be useful,
+*     but WITHOUT ANY WARRANTY; without even the implied warranty of
+*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*     GNU Lesser General Public License for more details.
+*
+*     You should have received a copy of the GNU Lesser General
+*     License along with this program.  If not, see
+*     <http://www.gnu.org/licenses/>.
+
+*  Authors:
+*     DSB: David S. Berry (Starlink)
+
+*  History:
+*     21-JAN-2019 (DSB):
+*        Original version.
+*/
+
+/* Define the astCLASS macro so that this file has access to the
+   protected API. */
+#define astCLASS pyast
+
+/* Include files: */
+/* -------------- */
+#include "mapping.h"
+#include "memory.h"
+#include "pyast_extra.h"
+#include "ast_err.h"
+
+
+/* Wrapper functions: */
+/* ------------------ */
+int astMapMergeID_( AstMapping *this, int where, int series, int *nmap,
+                    AstMapping ***id_list, int **invert_list, int *status ) {
+
+/* Local Variables: */
+   AstMapping **map_list = NULL;
+   int i;
+   int result = -1;
+
+/* Check inherited status */
+   if( !astOK ) return result;
+
+/* Get genuine pointers from the supplied ID values. */
+   map_list = astMalloc( (*nmap)*sizeof(*map_list) );
+   if( astOK ) {
+      for( i = 0; i < *nmap; i++ ) {
+         map_list[ i ] = astMakePointer( (*id_list)[ i ] );
+      }
+   }
+
+/* Check the "here" value is correct. */
+   if( this != map_list[ where ] && astOK ) {
+      astError( AST__INVAR, "astMapMerge(%s): The supplied mapping 'this' "
+                "(a %s) is not stored at the specified element (%d) of "
+                "the map_list array.", status, astGetClass(this),
+                astGetClass(this), where );
+   }
+
+/* The astMapMerge method call below may change annull one or more of the
+   supplied Mapping pointers. This could cause the underlying Mapping object
+   to be deleted. This can cause big problems for python. So ensure the
+   supplied pointers are not modified by taking deep copies. */
+   if( astOK ) {
+      for( i = 0; i < *nmap; i++ ) {
+         map_list[ i ] = astCopy( map_list[ i ] );
+      }
+   }
+
+/* Call the protected method. This returns a list of genuine Mapping
+   pointers in a newly allocated array. Call the function directly,
+   rather than through the usual macro API, to avoid calling this
+   function recursively. */
+   result = astMapMerge_( map_list[ where ], where, series, nmap, &map_list,
+                          invert_list, status );
+
+/* Store the ID values corresponding to the returned Mapping pointers,
+   adjusting the size of the supplied array as needed. These returned
+   pointers are independent of the supplied pointers because deep copies
+   of the supplied pointers were used above. */
+   *id_list = astGrow( *id_list, *nmap, sizeof(**id_list) );
+   if( astOK ) {
+      for( i = 0; i < *nmap; i++ ) {
+         (*id_list)[ i ] = astMakeId( map_list[ i ] );
+      }
+   }
+
+/* Free the array of mapping pointers. */
+   map_list = astFree( map_list );
+
+/* Return the index of the first modified mapping */
+   return result;
+}
+

--- a/ast/pyast_extra.h
+++ b/ast/pyast_extra.h
@@ -1,0 +1,70 @@
+#if !defined( PYAST_EXTRA_INCLUDED )   /* Include this file only once */
+#define PYAST_EXTRA_INCLUDED
+/*
+*  Name:
+*     pyast_extra.h
+
+*  Type:
+*     C include file.
+
+*  Purpose:
+*     Define the interface to the pyast_extra module.
+
+*  Invocation:
+*     #include "pyast_extra.h"
+
+*  Description:
+*     This include file defines the interface for the function in the
+*     file pyast_extra.c. These provide pyast with access to some protected
+*     features of AST.
+
+*  Copyright:
+*     Copyright (C) 2019 East Asian Observatory
+
+*  Licence:
+*     This program is free software: you can redistribute it and/or
+*     modify it under the terms of the GNU Lesser General Public
+*     License as published by the Free Software Foundation, either
+*     version 3 of the License, or (at your option) any later
+*     version.
+*
+*     This program is distributed in the hope that it will be useful,
+*     but WITHOUT ANY WARRANTY; without even the implied warranty of
+*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*     GNU Lesser General Public License for more details.
+*
+*     You should have received a copy of the GNU Lesser General
+*     License along with this program.  If not, see
+*     <http://www.gnu.org/licenses/>.
+
+*  Authors:
+*     DSB: B.S. Berry (EAO)
+
+*  History:
+*     21-JAN-2019 (DSB):
+*        Original version.
+*/
+
+/* Macros. */
+/* ------- */
+#define STATUS_PTR astGetStatusPtr
+
+/* Function prototypes. */
+/* -------------------- */
+int astMapMergeID_( AstMapping *, int, int, int *, AstMapping ***, int **, int * );
+
+/* Function interfaces. */
+/* -------------------- */
+/* These macros are wrap-ups for the functions defined by this class to make
+   them easier to invoke (e.g. to avoid type mis-matches when passing pointers
+   to objects from derived classes). */
+
+#define astMapMerge(this,where,series,nmap,id_list,invert_list) \
+astMapMergeID_(astCheckMapping(this),where,series,nmap,id_list,invert_list,STATUS_PTR)
+
+
+
+#endif
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ ast_c = ('axis.c', 'box.c', 'channel.c', 'circle.c', 'cmpframe.c',
          'sphmap.c', 'stcschan.c', 'timeframe.c', 'timemap.c', 'tpn.c',
          'tranmap.c', 'unit.c', 'unitmap.c', 'wcsmap.c', 'wcstrig.c',
          'winmap.c', 'xml.c', 'xphmap.c', 'zoommap.c', 'specmap.c',
-         'slamap.c', 'chebymap.c', 'unitnormmap.c' )
+         'slamap.c', 'chebymap.c', 'unitnormmap.c', 'pyast_extra.c' )
 
 #  List the erfa source files required by AST.
 erfa_c = ('a2af.c', 'a2tf.c', 'ab.c', 'af2a.c', 'anp.c', 'anpm.c',

--- a/starlink/ast/Ast.c
+++ b/starlink/ast/Ast.c
@@ -45,7 +45,7 @@ static char *GetString( void *mem, PyObject *value );
 static char *PyAst_ToString( PyObject *self );
 static const char *AttNorm( const char *att, char *buff );
 static void Sinka( const char *text );
-static const char *FormatObject( PyObject *o );
+static char *FormatObject( PyObject *o );
 const char *GetObjectType( PyObject *o );
 
 /* Macros used in this file */
@@ -13366,30 +13366,33 @@ static const char *AttNorm( const char *att, char *buff ){
 }
 
 
-const char *FormatObject( PyObject *o ){
+char *FormatObject( PyObject *o ){
 /*
 *  Name:
 *     FormatObject
 
 *  Purpose:
 *     Return a formatted representation of an arbitrary PyObject.
-*     The returned pointer points to static memory and must not be
-*     freed.
+*     The returned pointer points to dynamic memory and must be
+*     freed using astFree.
 
 */
-   const char *result = NULL;
+   const char *text = NULL;
+   char *result = NULL;
    PyObject *repr = PyObject_Repr( o );
 
    if( PyUnicode_Check( repr ) ) {
       PyObject *bytes = PyUnicode_AsASCIIString(repr);
       if( bytes ) {
-         result =  PyBytes_AS_STRING(bytes);
+         text =  PyBytes_AS_STRING(bytes);
+         if( text ) result = astStore( NULL, text, strlen( text ) + 1 );
          Py_DECREF(bytes);
       }
 
 #if PY_MAJOR_VERSION < 3
    } else if( PyString_Check( repr ) ) {
-      result =  PyString_AsString(repr);
+      text =  PyString_AsString(repr);
+      if( text ) result = astStore( NULL, text, strlen( text ) + 1 );
 #endif
    }
 

--- a/starlink/ast/test/test.py
+++ b/starlink/ast/test/test.py
@@ -606,7 +606,29 @@ class TestAst(unittest.TestCase):
         self.assertIsInstance(cmpmap, starlink.Ast.CmpMap)
         self.assertIsInstance(cmpmap, starlink.Ast.Mapping)
 
-        zoommap = starlink.Ast.ZoomMap(2, 1.0)
+        unitmap1 = starlink.Ast.UnitMap(2)
+        unitmap2 = starlink.Ast.UnitMap(2)
+        zoommap1 = starlink.Ast.ZoomMap(2, 1.5)
+        zoommap2 = starlink.Ast.ZoomMap(2, 2.0)
+        shiftmap = starlink.Ast.ShiftMap( [-1.0,-1.0] )
+        maplist = [unitmap1, zoommap1, shiftmap, unitmap2, zoommap2]
+        invlist = [0,0,0,0,1]
+        (result,newmaplist,newinvlist) = shiftmap.mapmerge( 2, True, maplist,
+                                                           invlist )
+        self.assertEqual(result,2)
+        self.assertEqual(len(newmaplist),5)
+        self.assertEqual(len(newinvlist),5)
+        self.assertIsInstance(newmaplist[0], starlink.Ast.UnitMap)
+        self.assertIsInstance(newmaplist[1], starlink.Ast.ZoomMap)
+        self.assertIsInstance(newmaplist[2], starlink.Ast.WinMap)
+        self.assertIsInstance(newmaplist[3], starlink.Ast.UnitMap)
+        self.assertIsInstance(newmaplist[4], starlink.Ast.ZoomMap)
+
+        del newmaplist
+        del maplist
+        del unitmap1, zoommap1, shiftmap, unitmap2, zoommap2
+
+        zoommap = starlink.Ast.ZoomMap(2, 2.0)
         unitmap = starlink.Ast.UnitMap(1)
         cmpmap = starlink.Ast.CmpMap(zoommap, unitmap, False)
         out, map = cmpmap.mapsplit(3)

--- a/starlink/include/star/pyast.h
+++ b/starlink/include/star/pyast.h
@@ -196,9 +196,11 @@ static int set##attrib( class *self, PyObject *value, void *closure ){ \
    } else { \
       setcode \
       if( result == -1 && !PyErr_Occurred()) { \
+         char *rep = FormatObject( value ); \
          PyErr_Format( PyExc_TypeError, "Bad value (%s) supplied " \
                        "for " #class " attribute '" #attrib "'.", \
-                       FormatObject( value ) ); \
+                       rep ); \
+         rep = astFree( rep ); \
       } \
    } \
    TIDY; \
@@ -627,9 +629,11 @@ MAKE_GET(class,attrib, \
       icol = PyLong_AsLong( value ); \
       astSetI(  ((Object*)self)->ast_object, ATTNORM(#attrib), icol ); \
    } else if( ! PyErr_Occurred() ) { \
+      char *rep = FormatObject(value); \
       PyErr_Format( PyExc_TypeError, "Cannot set attribute '" \
                     #attrib "' - value (%s) is not a known colour " \
-                    "name or an integer.", FormatObject(value) ); \
+                    "name or an integer.", rep ); \
+      rep = astFree( rep ); \
    } \
    if( astOK ) result = 0;
 


### PR DESCRIPTION
astMapMerge is a protected method of the Mapping class. So getting access to it from pyast requires a little extra effort. The new files pyast_extra.c/.h behave as if they were part of the AST source distribution, and so have access to protected features. of AST. The astMapMerge wrapper is mainly for use in the astviewer tool. It is not  documented.